### PR TITLE
Docker mac osx fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ This will produce an image called: ```harvarditsecurity/docker-misp```
     -v /misp-db:/var/lib/mysql \
     harvarditsecurity/misp /init-db
 ```
-Note: If running Docker on Mac OSX, you have to first create a shared path or the database
-will not initialize. This is due to the limited way OSX allows for volume binding. 
+Note: If running Docker on Mac OSX, you have to first explicitly create a shared directory
+path or the database will not initialize. This is due to the limited way OSX allows for volume binding. 
 
 ## 2. Start the container
 ```

--- a/README.md
+++ b/README.md
@@ -57,10 +57,16 @@ This will produce an image called: ```harvarditsecurity/docker-misp```
 ## 1. Initialize Database
 
 ```
-docker run -it --rm \
+    # for mac osx users, you need to run this command first(see note below):
+    docker run --rm -v /:/host alpine mkdir -p /host/misp-db
+    
+    # all others can start here
+    docker run -it --rm \
     -v /misp-db:/var/lib/mysql \
     harvarditsecurity/misp /init-db
 ```
+Note: If running Docker on Mac OSX, you have to first create a shared path or the database
+will not initialize. This is due to the limited way OSX allows for volume binding. 
 
 ## 2. Start the container
 ```


### PR DESCRIPTION
Hello,
The container as designed will not work on Mac OSX, so I inserted a command in the Readme.md that will solve the problem. I've tested it and it works fine on my Mac now. Previously it would not. See image attachments.

![dockerfix1](https://user-images.githubusercontent.com/14305193/37114577-6a1fa016-220e-11e8-90b2-f688c9f643ec.jpg)


![dockerfix2](https://user-images.githubusercontent.com/14305193/37114458-09261ba0-220e-11e8-9772-196a65c4ea3c.jpg)

Thanks for putting together this container- much easier to set-up and run than the other MISP container!
Cheers,
toby

