### PR TITLE
Pass redis conf file to redis-server program in supervisord.conf

### DIFF
--- a/container/supervisord.conf
+++ b/container/supervisord.conf
@@ -20,7 +20,7 @@ command=/usr/bin/mysqld_safe
 [program:redis-server]
 process_name = redis-server
 directory = /etc/redis
-command=/usr/bin/redis-server
+command=/usr/bin/redis-server /etc/redis/redis.conf
 user=redis
 
 [program:apache2]

--- a/container/supervisord.conf
+++ b/container/supervisord.conf
@@ -19,7 +19,7 @@ command=/usr/bin/mysqld_safe
 
 [program:redis-server]
 process_name = redis-server
-directory = /etc/redis
+directory = /var/lib/redis
 command=/usr/bin/redis-server /etc/redis/redis.conf
 user=redis
 


### PR DESCRIPTION
Previously, the redis-server program was started from supervisord.conf
without a configuration file specifying the data directory to use. This
resulted in redis "not able to persist to disk" errors when MISP ZeroMQ
was enabled and the associated mispzmq script performed some redis
commands. The error was due to the default redis data directory,
/etc/redis, not being writable by the user that the redis process runs as, redis.

This commit passes the /etc/redis/redis.conf configuration file to the
redis-server process at startup. The configuration file already sets the
data directory to a directory that the redis user has write access to,
/var/lib/redis. This allows the mispzmq script's calls to redis to be
successful.

Thanks for all of your hard work maintaining this project and for
considering this change.