### PR TITLE
Cybox library version error fix

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -43,15 +43,15 @@ RUN sudo -u www-data -H git clone https://github.com/CybOXProject/python-cybox.g
     sudo -u www-data -H git clone https://github.com/STIXProject/python-stix.git
 
 WORKDIR /var/www/MISP/app/files/scripts/python-cybox
-RUN python3 setup.py install
+RUN sudo python3 setup.py install
 
 WORKDIR /var/www/MISP/app/files/scripts/python-stix
-RUN python3 setup.py install
+RUN sudo python3 setup.py install
 
 WORKDIR /var/www/MISP/app/files/scripts/
 RUN sudo -u www-data -H git clone https://github.com/CybOXProject/mixbox.git ; \
     cd /var/www/MISP/app/files/scripts/mixbox ; \
-    python3 setup.py install
+    sudo python3 setup.py install
 
 WORKDIR /var/www/MISP
 RUN sudo -u www-data -H git submodule init ; \
@@ -128,9 +128,6 @@ RUN sed -i -e 's/db login/misp/g' /var/www/MISP/app/Config/database.php ; \
     sed -i -e "s/bind 127.0.0.1 ::1/bind 0.0.0.0/" /etc/redis/redis.conf ; \
     sudo chown -R www-data:www-data /var/www/MISP/app/Config ; \
     sudo chmod -R 750 /var/www/MISP/app/Config ; \
-    sudo pip2 install --upgrade pip ; \
-    sudo pip2 install pyzmq ; \
-    sudo pip2 install redis ; \
     sudo pip3 install --upgrade pip ; \
     sudo pip3 install pyzmq ; \
     sudo pip3 install redis ; \
@@ -192,8 +189,8 @@ RUN echo "/var/www/MISP/app/tmp/logs/resque-*-error.log {" > misp ; \
     echo "      weekly" >> misp ; \
     echo "      copytruncate" >> misp ; \
     echo "}" >> misp
-    
-    
+
+
 WORKDIR /var/www/MISP
 COPY supervisord.conf /etc/supervisor/conf.d/
 

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -73,6 +73,8 @@ WORKDIR /usr/local/src/misp-modules
 RUN sudo pip3 install -I -r REQUIREMENTS ;  \
     sudo pip3 install -I .
 
+RUN sudo pip3 uninstall -y cybox
+
 WORKDIR /var/www/MISP/app
 RUN mkdir /var/www/.composer && chown -R www-data:www-data /var/www/.composer ; \
     sudo -u www-data -H wget https://getcomposer.org/download/1.2.1/composer.phar -O composer.phar ; \


### PR DESCRIPTION
After a clean install if you log into MISP and navigate to Administration -> Server Settings -> Diagnostics in the STIX and Cybox libraries section you will see the error CYBOX library version...Incorrect CyBox version installed, found 2.1.0.17 expecting 2.1.0.18.dev0.  I reached out the the developers of MISP and they told me to run pip3 uninstall cybox to uninstall the pip managed version.  To test it out I did I clean install and SSH'd into the container then ran the command and the error went away.  Not sure where the best place to incorporate this is, but this was were I tested it and I successfully ran a clean build with it.