### PR TITLE
Update Dockerfile ssdeep download location

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -132,8 +132,8 @@ RUN sed -i -e 's/db login/misp/g' /var/www/MISP/app/Config/database.php ; \
     sed -i -e "s/bind 127.0.0.1 ::1/bind 0.0.0.0/" /etc/redis/redis.conf ; \
     sudo chown -R www-data:www-data /var/www/MISP/app/Config ; \
     sudo chmod -R 750 /var/www/MISP/app/Config ; \
-    sudo -u www-data -H wget http://downloads.sourceforge.net/project/ssdeep/ssdeep-2.13/ssdeep-2.13.tar.gz ; \
-    tar zxvf ssdeep-2.13.tar.gz && cd ssdeep-2.13 && ./configure && make && sudo make install ; \
+    sudo -u www-data -H wget https://github.com/ssdeep-project/ssdeep/releases/download/release-2.14.1/ssdeep-2.14.1.tar.gz ; \
+    tar zxvf ssdeep-2.14.1.tar.gz && cd ssdeep-2.14.1.tar.gz && ./configure && make && sudo make install ; \
     sudo pecl install ssdeep ; \
     sudo echo "extension=ssdeep.so" > /etc/php/7.2/mods-available/ssdeep.ini ; \
     sudo phpenmod ssdeep ; \


### PR DESCRIPTION
- For ssdeep install, use github.com instead of http://sourceforge.net.
- Update ssdeep version form 2.13 to 2.14.1